### PR TITLE
Improve input handling

### DIFF
--- a/baseGame/dino.js
+++ b/baseGame/dino.js
@@ -7,7 +7,9 @@ const dino = {
     height: 50,
     dy: 0,
     jumping: false,
+    jumpHeld: false,
     crouching: false,
+    crouchHeld: false,
 
     draw() {
         const height = this.crouching ? this.height / 2 : this.height;
@@ -17,6 +19,13 @@ const dino = {
     },
 
     update(deltaTime) {
+        
+        // Handle Jump input
+        if (this.jumpHeld && !this.jumping && !this.crouching) { 
+            this.jumping = true;
+            this.dy = -12; 
+        }
+        
         // Apply gravity when jumping
         if (this.jumping) {
             this.dy += gravity * deltaTime;
@@ -28,6 +37,12 @@ const dino = {
                 this.dy = 0;
                 this.jumping = false;
             }
+        }
+        
+        if (!this.jumping && this.crouchHeld) {
+            this.crouching = this.crouchHeld;
+        } else {
+            this.crouching = false;
         }
 
         // Adjust height based on crouching status
@@ -42,17 +57,12 @@ const dino = {
         }
     },
 
-    jump() {
-        if (!this.jumping && !this.crouching) { 
-            this.jumping = true;
-            this.dy = -12; 
-        }
+    jump(state) {
+        this.jumpHeld = state;
     },
 
     crouch(state) {
-        if (!this.jumping) {
-            this.crouching = state;
-        }
+        this.crouchHeld = state;
     }
 };
 

--- a/baseGame/ui.js
+++ b/baseGame/ui.js
@@ -21,42 +21,40 @@ function displayText(text, fontSize = 20, color = 'black', x = 0, y = 0) {
 // Event listeners
 document.addEventListener('keydown', async (e) => {
     if (e.code === 'Space' && !getGameOver()) {
-        dino.jump();
+        dino.jump(true);
     } else if (e.code === 'KeyC' && !getGameOver()) {
         dino.crouch(true);
-    } else if (e.code === 'KeyT' && !getGameStarted()) {
+    } else  if (e.code === 'KeyT' && !getGameStarted()) {
         setPaused(false);  // Unpause the game
         setGameStarted(true);  // Mark the game as started
+      //  resetGame();  // Reset the game before starting
         document.getElementById('ellipse').style.display = 'none';
         startGameLoop();  // Start the game loop
-    } else if (e.code === 'KeyR' && getGameOver()) {
-        if (!getNameEnter()) {
-            resetGame(); // Reset before starting
-            setPaused(false);  // Unpause the game
-            setGameStarted(true);  // Mark the game as started
-            startGameLoop();  // Start the game loop
-            let scoreInput = document.getElementById("scoreInput");
-            if (scoreInput) {
-                scoreInput.remove();
-            }
-        } else {
-            alert("You cannot reset the game while entering your name for the leaderboard.");
+    }  else if (e.code === 'KeyR' && getGameOver() && !getNameEnter()) {
+		resetGame(); // Reset before starting
+        setPaused(false);  // Unpause the game
+        setGameStarted(true);  // Mark the game as started
+        startGameLoop();  // Start the game loop
+        // Remove the score input if it exists
+        let scoreInput = document.getElementById("scoreInput");
+        if (scoreInput) {
+            scoreInput.remove();
         }
     } else if (e.code === 'KeyP' && !getGameOver() && getGameStarted()) {
         // Toggle pause
-        console.log("Paused State: ", getPaused());
+		console.log("Paused State: ", getPaused());
         console.log("Game Over State: ", getGameOver());
         let pausedState = getPaused();
-        setPaused(!pausedState);
+        setPaused(!pausedState);  
         if (!pausedState) {
             document.getElementById('pauseScreen').style.display = 'flex';  // Show overlay
-        } else {
+        } else {          
             gameLoop();
             document.getElementById('pauseScreen').style.display = 'none';  // Hide overlay
         }
-    } else if (e.code === 'KeyA' && !getGameOver()) {
+	 }  else if (e.code === 'KeyA' && !getGameOver()) {
         console.log(await addScore("xX_Ghost_Xx", Math.floor(Math.random() * 1001), "weekly"));
-    } else if (e.code === 'KeyG' && !getGameOver()) {
+    }   else if (e.code === 'KeyG' && !getGameOver()) {
         console.log(await getScores("weekly"));
     }
 });
@@ -64,15 +62,21 @@ document.addEventListener('keydown', async (e) => {
 document.addEventListener('keyup', (e) => {
     if (e.code === 'KeyC') {
         dino.crouch(false);  // Stop crouching when 'C' is released
+    } else if (e.code === 'Space') {
+        dino.jump(false);
     }
 });
 
 // Button event listeners for Play screen
-document.getElementById('jumpButton').addEventListener('click', () => {
+document.getElementById('jumpButton').addEventListener('mousedown', () => {
     if (!getGameOver()) {
-        dino.jump();
-		
+        dino.jump(true);
+    }
+});
 
+document.getElementById('jumpButton').addEventListener('mouseup', () => {
+    if (!getGameOver()) {
+        dino.jump(false);
     }
 });
 
@@ -98,18 +102,14 @@ document.getElementById('startButton').addEventListener('click', () => {
 
 document.getElementById('restartButton').addEventListener('click', () => {
     if (getGameOver()) {
-        if (!getNameEnter()) {
-            resetGame(); // Reset before starting
-            setPaused(false);  // Unpause the game
-            setGameStarted(true);  // Mark the game as started
-            startGameLoop();  // Start the game loop
+        resetGame(); // Reset before starting
+        setPaused(false);  // Unpause the game
+        setGameStarted(true);  // Mark the game as started
+        startGameLoop();  // Start the game loop
 
-            let scoreInput = document.getElementById("scoreInput");
-            if (scoreInput) {
-                scoreInput.remove();
-            }
-        } else {
-            alert("You cannot reset the game while entering your name for the leaderboard.");
+        let scoreInput = document.getElementById("scoreInput");
+        if (scoreInput) {
+            scoreInput.remove();
         }
     }
 });


### PR DESCRIPTION
Currently, the game only applies crouching and jumping right when the key is pressed or the button is clicked. This lead to game having a feeling of low responsiveness. This is because if crouch started to be held while jumping in the air, you would not crouch right when you land, and if jump started to be held when crouching, you would not jump when letting go of crouch. This PR fixes that by having the inputs only set a state of being held, and the player checks these states on every frame, instead of waiting to be told by the input handler.