### PR TITLE
Load the daily seed, and validate scores as they come in to the server

### DIFF
--- a/baseGame/game.js
+++ b/baseGame/game.js
@@ -3,13 +3,15 @@ import { dino } from './dino.js';
 import { displayText } from './ui.js';
 import { BackgroundManager } from './background.js';
 
-const levelSeed = Math.floor(Date.now() / 1000);
+const now = new Date();
+const startOfDayUTC = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+const levelSeed = Math.floor(startOfDayUTC / 1000);
 // const levelSeed = 1731697424;
 
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
-const serverUrl = 'http://45.83.107.132:5000/project_ghost/';
-//const serverUrl = 'http://localhost:5000/project_ghost/';
+// const serverUrl = 'http://45.83.107.132:5000/project_ghost/';
+const serverUrl = 'http://localhost:5000/project_ghost/';
 
 
 // Add background music

--- a/serverBackend/app.py
+++ b/serverBackend/app.py
@@ -85,7 +85,7 @@ def add_score():
 				raise Exception("Input seed does not match daily seed")
 
 			# Ensure the user name is no longer than 3 characters
-			if data["user_name"].length > 3:
+			if len(data["user_name"]) > 3:
 				raise Exception("User name is too long. Must be 3 or less letters")
 
 			# Ensure the score entered is an int

--- a/serverBackend/app.py
+++ b/serverBackend/app.py
@@ -81,9 +81,24 @@ def add_score():
 		
 		for category in data['categories']:
 			# Ensure the seed (timestamp) matches the daily seed
-			in_timestamp = data["timestamp"]
-			if in_timestamp != seed:
+			if data["timestamp"] != seed:
 				raise Exception("Input seed does not match daily seed")
+
+			# Ensure the user name is no longer than 3 characters
+			if data["user_name"].length > 3:
+				raise Exception("User name is too long. Must be 3 or less letters")
+
+			# Ensure the score entered is an int
+			if type(data["score"]) != int:
+				raise Exception("Scores must be a positive integer")
+
+			# Ensure the scores is not negative
+			if data["score"] < 0:
+				raise Exception("Scores must be a positive integer")
+
+			# Ensure the score is no bigger than SQLite's max int size
+			if data["score"] > ((2**63)-1):
+				raise Exception("Scores cannot be larger than '(2^63)-1'")
 
 			# Determine the table to add to
 			table = tables[category]

--- a/serverBackend/app.py
+++ b/serverBackend/app.py
@@ -75,7 +75,16 @@ def add_score():
 		
 	# Insert the new score into the databases
 	try:
+		
+		# Get the daily seed, to ensure this score matches
+		seed = LevelSeed.select().first().seed
+		
 		for category in data['categories']:
+			# Ensure the seed (timestamp) matches the daily seed
+			in_timestamp = data["timestamp"]
+			if in_timestamp != seed:
+				raise Exception("Input seed does not match daily seed")
+
 			# Determine the table to add to
 			table = tables[category]
 			

--- a/serverBackend/app.py
+++ b/serverBackend/app.py
@@ -1,6 +1,6 @@
 from flask import Flask, jsonify, request, render_template
 from flask_cors import CORS, cross_origin
-from database import tables # import our database handling code
+from database import tables, LevelSeed # import our database handling code
 import time, os
 
 app = Flask(__name__, static_folder='../baseGame', template_folder='../baseGame')

--- a/serverBackend/database.py
+++ b/serverBackend/database.py
@@ -22,8 +22,15 @@ class WeeklyScores(Scores):
 class AllTime(Scores):
 	pass
 	
+class LevelSeed(Model):
+	seed = IntegerField()
+	
+	class Meta:
+		database = db
+		abstract = True
+		
 db.connect()
-db.create_tables([DailyScores, WeeklyScores, AllTime]) # only creates tables when they don't exist
+db.create_tables([DailyScores, WeeklyScores, AllTime, LevelSeed]) # only creates tables when they don't exist
 
 # Map the string name of the table to the table. This will be used in the HTTP requests
 tables = {
@@ -36,12 +43,15 @@ def auto_reset():
 	max_retries = 5
 	retry_count = 0
 	today = datetime.datetime.today()
+	timestamp = int(today.replace(hour=0, minute=0, second=0, microsecond=0).timestamp())
 	while retry_count < max_retries:
 		try:
 			if today.weekday() == 0: # Monday
 				WeeklyScores.delete().execute()
 				
 			DailyScores.delete().execute()
+			LevelSeed.delete().execute()
+			LevelSeed.create(seed=timestamp)
 			break
 			
 		except OperationalError as oe:

--- a/serverBackend/database.py
+++ b/serverBackend/database.py
@@ -42,7 +42,7 @@ tables = {
 def auto_reset():
 	max_retries = 5
 	retry_count = 0
-	today = datetime.datetime.today()
+	today = today = datetime.datetime.now(datetime.UTC)
 	timestamp = int(today.replace(hour=0, minute=0, second=0, microsecond=0).timestamp())
 	while retry_count < max_retries:
 		try:


### PR DESCRIPTION
The client and server independently generate the level seed (obtained from the current time in UTC). They both generate the same number, and thus will be in sync, and no network activity has to happen at all for everyone to have the same level at the same time!

Scores added to the server are now validated against three criteria:
1. The level seed must match the server's level seed
2. The user name must not be longer than three characters
3. The score must not be greater than SQLite's max integer size ( (2^63)-1 )

Completes #110 and #111